### PR TITLE
STYLE | ajusta responsividade

### DIFF
--- a/src/frontend/src/mobile/pages/PaymentView.tsx
+++ b/src/frontend/src/mobile/pages/PaymentView.tsx
@@ -26,32 +26,33 @@ interface Payment {
 
 export default function PagamentosImovel() {
   const { imovelid } = useParams<{ imovelid: string }>(); // Captura o imovelid da URL
-  const { paymentid } = useParams<{paymentid: string }>();
+  const { paymentid } = useParams<{ paymentid: string }>();
   const [isEditable, setIsEditable] = useState(false); // Controla se o formulário é editável
   const [payments, setPayments] = useState<Payment[]>([]); // Lista de pagamentos
   const [loadingSkeleton, setLoadingSkeleton] = useState(true); // Loading inicial
   const [loadingSpinner, setLoadingSpinner] = useState(false); // Loading durante salvamento
   const [role] = useAtom(userRoleAtom);
-  
+
   const fetchPayments = async () => {
     setLoadingSkeleton(true);
     try {
-      const requestUrl = role === "Admin"
-        ? `payment/payment/pagamentos/${paymentid}`
-        : `payment/payment/ByImovel/${imovelid}`;
-  
+      const requestUrl =
+        role === "Admin"
+          ? `payment/payment/pagamentos/${paymentid}`
+          : `payment/payment/ByImovel/${imovelid}`;
+
       const response = await axiosInstance.get(requestUrl);
-  
+
       if (!response.data) {
         console.error("Dados de resposta inválidos");
         return;
       }
-  
+
       // Verifica o tipo de resposta e normaliza para um array
       const normalizedPayments = Array.isArray(response.data)
         ? response.data
         : [response.data];
-  
+
       // Define os pagamentos retornados pela API
       setPayments(normalizedPayments);
       console.log("Pagamentos recebidos:", normalizedPayments);
@@ -62,9 +63,8 @@ export default function PagamentosImovel() {
       setLoadingSkeleton(false);
     }
   };
-  
+
   useEffect(() => {
-    
     fetchPayments();
     setIsEditable(role === "Admin"); // Somente admin pode editar
   }, [imovelid]);
@@ -74,7 +74,10 @@ export default function PagamentosImovel() {
 
     try {
       // Simulação de uma requisição PUT para atualizar o pagamento
-      await axiosInstance.put(`payment/payment/atualizar-pagamento/${payment.paymentId}`, payment);
+      await axiosInstance.put(
+        `payment/payment/atualizar-pagamento/${payment.paymentId}`,
+        payment
+      );
       showSuccessToast("Pagamento atualizado com sucesso!");
       fetchPayments(); // Atualiza a lista de pagamentos após salvar
     } catch (error) {
@@ -96,143 +99,26 @@ export default function PagamentosImovel() {
           <Loading type="skeleton" />
         ) : (
           <div className="flex flex-col justify-center items-center">
-            <h1 className="w-full font-bold text-lg">Pagamentos do Imóvel {imovelid}</h1>
+            <div className="flex flex-col gap-4 w-[42rem] m-auto">
+              <h1 className="w-full font-bold text-lg">
+                Pagamentos do Imóvel {imovelid}
+              </h1>
 
-            {payments.length > 0 ? (
-              payments.map((payment) => (
-                <form
-                  key={payment.paymentId}
-                  className="w-full max-w-5xl flex flex-col gap-5 mb-8 p-4 border rounded-lg shadow-sm"
-                  onSubmit={(e) => {
-                    e.preventDefault();
-                    handleSave(payment);
-                  }}
-                >
-                  <div className="flex flex-col">
-                    <label htmlFor="valor">Valor:</label>
-                    <CurrencyInput
-                      id="valor"
-                      name="valor"
-                      placeholder="R$ 0,00"
-                      decimalSeparator=","
-                      groupSeparator="."
-                      prefix="R$ "
-                      decimalsLimit={2}
-                      maxLength={9}
-                      className="w-full p-2 h-10 border rounded-md focus:outline-none border-gray-300 focus:border-blue-500 tracking-wide text-neutral-700 font-light text-sm"
-                      value={payment.valor || ""}
-                      onValueChange={(newValue) =>
-                        setPayments((prev) =>
-                          prev.map((p) =>
-                            p.paymentId === payment.paymentId
-                              ? { ...p, valor: parseFloat(newValue || "0") }
-                              : p
-                          )
-                        )
-                      }
-                      disabled={!isEditable}
-                    />
-                  </div>
-                  <div className="flex flex-col">
-                    <label htmlFor="data">Data:</label>
-                    <input
-                      id="data"
-                      type="date"
-                      value={
-                        payment.data
-                          ? payment.data.split("T")[0] // Extrai apenas a parte da data
-                          : ""
-                      }
-                      onChange={(e) =>
-                        setPayments((prev) =>
-                          prev.map((p) =>
-                            p.paymentId === payment.paymentId
-                              ? { ...p, data: e.target.value }
-                              : p
-                          )
-                        )
-                      }
-                      className="w-full p-2 h-10 border rounded-md focus:outline-none border-gray-300 focus:border-blue-500 tracking-wide text-neutral-700 font-light text-sm"
-                      required
-                      disabled={!isEditable}
-                    />
-                  </div>
-                  <div className="flex flex-col">
-                    <label htmlFor="pagante">Pagante:</label>
-                    <input
-                      id="pagante"
-                      type="text"
-                      value={payment.pagante || ""}
-                      onChange={(e) =>
-                        setPayments((prev) =>
-                          prev.map((p) =>
-                            p.paymentId === payment.paymentId
-                              ? { ...p, pagante: e.target.value }
-                              : p
-                          )
-                        )
-                      }
-                      className="w-full p-2 h-10 border rounded-md focus:outline-none border-gray-300 focus:border-blue-500 tracking-wide text-neutral-700 font-light text-sm"
-                      required
-                      disabled={!isEditable}
-                    />
-                  </div>
-                  <div className="flex flex-col">
-                    <label htmlFor="metodoPagamento">Método de Pagamento:</label>
-                    <select
-                      id="metodoPagamento"
-                      name="metodoPagamento"
-                      value={payment.metodoPagamento || ""}
-                      onChange={(e) =>
-                        setPayments((prev) =>
-                          prev.map((p) =>
-                            p.paymentId === payment.paymentId
-                              ? { ...p, metodoPagamento: e.target.value }
-                              : p
-                          )
-                        )
-                      }
-                      className="w-full p-2 h-10 border rounded-md focus:outline-none border-gray-300 focus:border-blue-500 tracking-wide text-neutral-700 font-light text-sm"
-                      required
-                      disabled={!isEditable}
-                    >
-                      <option value="Pix">Pix</option>
-                      <option value="Boleto">Boleto</option>
-                      <option value="Débito">Débito</option>
-                      <option value="Crédito">Crédito</option>
-                    </select>
-                  </div>
-                  <div className="flex flex-col">
-                    <label htmlFor="tipoPagamento">Tipo de Pagamento:</label>
-                    <select
-                      id="tipoPagamento"
-                      name="tipoPagamento"
-                      value={payment.tipoPagamento || ""}
-                      onChange={(e) =>
-                        setPayments((prev) =>
-                          prev.map((p) =>
-                            p.paymentId === payment.paymentId
-                              ? { ...p, tipoPagamento: e.target.value }
-                              : p
-                          )
-                        )
-                      }
-                      className="w-full p-2 h-10 border rounded-md focus:outline-none border-gray-300 focus:border-blue-500 tracking-wide text-neutral-700 font-light text-sm"
-                      required
-                      disabled={!isEditable}
-                    >
-                      <option value="Mensalidade">Mensalidade</option>
-                      <option value="Multa">Multa</option>
-                      <option value="Reforma">Reforma</option>
-                    </select>
-                  </div>
-
-                  {payment.tipoPagamento === "Multa" && (
+              {payments.length > 0 ? (
+                payments.map((payment) => (
+                  <form
+                    key={payment.paymentId}
+                    className="w-full max-w-5xl flex flex-col gap-5 mb-8 p-4 border rounded-lg shadow-sm"
+                    onSubmit={(e) => {
+                      e.preventDefault();
+                      handleSave(payment);
+                    }}
+                  >
                     <div className="flex flex-col">
-                      <label htmlFor="valorMulta">Valor da Multa:</label>
+                      <label htmlFor="valor">Valor:</label>
                       <CurrencyInput
-                        id="valorMulta"
-                        name="valorMulta"
+                        id="valor"
+                        name="valor"
                         placeholder="R$ 0,00"
                         decimalSeparator=","
                         groupSeparator="."
@@ -240,12 +126,12 @@ export default function PagamentosImovel() {
                         decimalsLimit={2}
                         maxLength={9}
                         className="w-full p-2 h-10 border rounded-md focus:outline-none border-gray-300 focus:border-blue-500 tracking-wide text-neutral-700 font-light text-sm"
-                        value={payment.valorMulta || ""}
+                        value={payment.valor || ""}
                         onValueChange={(newValue) =>
                           setPayments((prev) =>
                             prev.map((p) =>
                               p.paymentId === payment.paymentId
-                                ? { ...p, valorMulta: parseFloat(newValue || "0") }
+                                ? { ...p, valor: parseFloat(newValue || "0") }
                                 : p
                             )
                           )
@@ -253,36 +139,167 @@ export default function PagamentosImovel() {
                         disabled={!isEditable}
                       />
                     </div>
-                  )}
-                  <div className="flex flex-col">
-                    <label htmlFor="descricao">Descrição:</label>
-                    <textarea
-                      id="descricao"
-                      value={payment.descricao || ""}
-                      onChange={(e) =>
-                        setPayments((prev) =>
-                          prev.map((p) =>
-                            p.paymentId === payment.paymentId
-                              ? { ...p, descricao: e.target.value }
-                              : p
+                    <div className="flex flex-col">
+                      <label htmlFor="data">Data:</label>
+                      <input
+                        id="data"
+                        type="date"
+                        value={
+                          payment.data
+                            ? payment.data.split("T")[0] // Extrai apenas a parte da data
+                            : ""
+                        }
+                        onChange={(e) =>
+                          setPayments((prev) =>
+                            prev.map((p) =>
+                              p.paymentId === payment.paymentId
+                                ? { ...p, data: e.target.value }
+                                : p
+                            )
                           )
-                        )
-                      }
-                      className="w-full p-2 border rounded-md focus:outline-none border-gray-300 focus:border-blue-500 tracking-wide text-neutral-700 font-light text-sm h-24 resize-none"
-                      maxLength={350}
-                      disabled={!isEditable}
-                    />
-                  </div>
+                        }
+                        className="w-full p-2 h-10 border rounded-md focus:outline-none border-gray-300 focus:border-blue-500 tracking-wide text-neutral-700 font-light text-sm"
+                        required
+                        disabled={!isEditable}
+                      />
+                    </div>
+                    <div className="flex flex-col">
+                      <label htmlFor="pagante">Pagante:</label>
+                      <input
+                        id="pagante"
+                        type="text"
+                        value={payment.pagante || ""}
+                        onChange={(e) =>
+                          setPayments((prev) =>
+                            prev.map((p) =>
+                              p.paymentId === payment.paymentId
+                                ? { ...p, pagante: e.target.value }
+                                : p
+                            )
+                          )
+                        }
+                        className="w-full p-2 h-10 border rounded-md focus:outline-none border-gray-300 focus:border-blue-500 tracking-wide text-neutral-700 font-light text-sm"
+                        required
+                        disabled={!isEditable}
+                      />
+                    </div>
+                    <div className="flex flex-col">
+                      <label htmlFor="metodoPagamento">
+                        Método de Pagamento:
+                      </label>
+                      <select
+                        id="metodoPagamento"
+                        name="metodoPagamento"
+                        value={payment.metodoPagamento || ""}
+                        onChange={(e) =>
+                          setPayments((prev) =>
+                            prev.map((p) =>
+                              p.paymentId === payment.paymentId
+                                ? { ...p, metodoPagamento: e.target.value }
+                                : p
+                            )
+                          )
+                        }
+                        className="w-full p-2 h-10 border rounded-md focus:outline-none border-gray-300 focus:border-blue-500 tracking-wide text-neutral-700 font-light text-sm"
+                        required
+                        disabled={!isEditable}
+                      >
+                        <option value="Pix">Pix</option>
+                        <option value="Boleto">Boleto</option>
+                        <option value="Débito">Débito</option>
+                        <option value="Crédito">Crédito</option>
+                      </select>
+                    </div>
+                    <div className="flex flex-col">
+                      <label htmlFor="tipoPagamento">Tipo de Pagamento:</label>
+                      <select
+                        id="tipoPagamento"
+                        name="tipoPagamento"
+                        value={payment.tipoPagamento || ""}
+                        onChange={(e) =>
+                          setPayments((prev) =>
+                            prev.map((p) =>
+                              p.paymentId === payment.paymentId
+                                ? { ...p, tipoPagamento: e.target.value }
+                                : p
+                            )
+                          )
+                        }
+                        className="w-full p-2 h-10 border rounded-md focus:outline-none border-gray-300 focus:border-blue-500 tracking-wide text-neutral-700 font-light text-sm"
+                        required
+                        disabled={!isEditable}
+                      >
+                        <option value="Mensalidade">Mensalidade</option>
+                        <option value="Multa">Multa</option>
+                        <option value="Reforma">Reforma</option>
+                      </select>
+                    </div>
 
-                  {/* Botão Salvar Alterações */}
-                  {isEditable && <Botao label="Salvar Alterações" onClick={() => handleSave(payment)}/>}
-                </form>
-              ))
-            ) : (
-              <p className="text-center text-lg text-neutral-500 mt-8 font-bold">
-                Nenhum pagamento encontrado.
-              </p>
-            )}
+                    {payment.tipoPagamento === "Multa" && (
+                      <div className="flex flex-col">
+                        <label htmlFor="valorMulta">Valor da Multa:</label>
+                        <CurrencyInput
+                          id="valorMulta"
+                          name="valorMulta"
+                          placeholder="R$ 0,00"
+                          decimalSeparator=","
+                          groupSeparator="."
+                          prefix="R$ "
+                          decimalsLimit={2}
+                          maxLength={9}
+                          className="w-full p-2 h-10 border rounded-md focus:outline-none border-gray-300 focus:border-blue-500 tracking-wide text-neutral-700 font-light text-sm"
+                          value={payment.valorMulta || ""}
+                          onValueChange={(newValue) =>
+                            setPayments((prev) =>
+                              prev.map((p) =>
+                                p.paymentId === payment.paymentId
+                                  ? {
+                                      ...p,
+                                      valorMulta: parseFloat(newValue || "0"),
+                                    }
+                                  : p
+                              )
+                            )
+                          }
+                          disabled={!isEditable}
+                        />
+                      </div>
+                    )}
+                    <div className="flex flex-col">
+                      <label htmlFor="descricao">Descrição:</label>
+                      <textarea
+                        id="descricao"
+                        value={payment.descricao || ""}
+                        onChange={(e) =>
+                          setPayments((prev) =>
+                            prev.map((p) =>
+                              p.paymentId === payment.paymentId
+                                ? { ...p, descricao: e.target.value }
+                                : p
+                            )
+                          )
+                        }
+                        className="w-full p-2 border rounded-md focus:outline-none border-gray-300 focus:border-blue-500 tracking-wide text-neutral-700 font-light text-sm h-24 resize-none"
+                        maxLength={350}
+                        disabled={!isEditable}
+                      />
+                    </div>
+
+                    {/* Botão Salvar Alterações */}
+                    {isEditable && (
+                      <Botao
+                        label="Salvar Alterações"
+                        onClick={() => handleSave(payment)}
+                      />
+                    )}
+                  </form>
+                ))
+              ) : (
+                <p className="text-center text-lg text-neutral-500 mt-8 font-bold">
+                  Nenhum pagamento encontrado.
+                </p>
+              )}
+            </div>
           </div>
         )}
       </section>


### PR DESCRIPTION
# Changelog

- ajusta a responsividade para fazer com que o título acompanhe o formulário

Observação: Embora a issue aponte um erro de estilização nesta página, a única inconsistência identificada foi o título sempre posicionado no início. Suponho que a percepção do problema possa estar relacionada ao fato de que, dependendo da role do usuário, o formulário não é editável e, por isso, aparece esmaecido. Esse efeito visual, no entanto, não representa uma falha de estilo, mas sim uma forma intencional de indicar ao usuário que os dados não podem ser alterados. Quando o formulário está editável, ele segue corretamente o padrão estético definido para formulários preenchíveis.